### PR TITLE
Use Footer colors from template/_colors.scss instead of hard-coded values

### DIFF
--- a/scss/configuration/template/_colors.scss
+++ b/scss/configuration/template/_colors.scss
@@ -45,8 +45,8 @@ $bottom-bg:						#f7f7f7;
 $bottom-text:					$core-text;
 
 // Footer
-$footer-bg:						#404040;
-$footer-text:					#ccc;
+$footer-bg:						#333;
+$footer-text:					#999;
 
 $rule-color: 					#F0F2F4;
 $code-text:						#c7254e;

--- a/scss/template/_footer.scss
+++ b/scss/template/_footer.scss
@@ -1,13 +1,13 @@
 // Footer styling
 #footer {
 	position: absolute;
-	background: #333;
+	background: $footer-bg;
 	height: $footer-height;
 	right: 0;
 	bottom: 0;
 	left: 0;
 	@extend .padding-horiz;
-	color: #999;
+	color: $footer-text;
 	text-align: center;
 
 	a:hover {
@@ -23,7 +23,7 @@
 		span {
 			font-size: 1.7rem;
 			line-height: 2.5rem;
-			background: #333;
+			background: $footer-bg;
 			width: 3rem;
 			height: 2rem;
 			border-radius: $border-radius;


### PR DESCRIPTION
While building a custom theme based on antimatter, I noticed that changing the `$footer-bg` and `$footer-text` variables in `scss/configuration/template/_colors.scss` did not have any influence on the footer appearance.

Instead, the colors were hard-coded in `scss/template/_footer.scss`, while the variables were never used anywhere (according to `grep`).
