### PR TITLE
Enable 100%-height elements on page

### DIFF
--- a/js/antimatter.js
+++ b/js/antimatter.js
@@ -9,29 +9,28 @@ function scrollHeader() {
         $("#header").removeClass("scrolled");
 }
 
-// ON SCROLL EVENTS
-if (!isTouch){
-    jQuery(document).scroll(function() {
-        scrollHeader();
-    });
-};
-
-// TOUCH SCROLL
-jQuery(document).on({
-    'touchmove': function(e) {
-        scrollHeader(); // Replace this with your code.
-    }
-});
-
-
 jQuery(document).ready(function($){
 
-	//Smooth scroll to top
-	$('#toTop').click(function(){
-		$("html, body").animate({ scrollTop: 0 }, 500);
-		return false;
-	});
-	// Responsive Menu
+    // ON SCROLL EVENTS
+    if (!isTouch){
+        $("body").scroll(function() {
+            scrollHeader();
+        });
+    };
+
+    // TOUCH SCROLL
+    $("body").on({
+        'touchmove': function(e) {
+            scrollHeader(); // Replace this with your code.
+        }
+    });
+
+    //Smooth scroll to top
+    $('#toTop').click(function(){
+        $("html, body").animate({ scrollTop: 0 }, 500);
+        return false;
+    });
+    // Responsive Menu
 
 });
 

--- a/scss/template/_core.scss
+++ b/scss/template/_core.scss
@@ -1,5 +1,5 @@
 html, body {
-	height: 100%;
+	height: 100% !important; // user !important to override slidebars.min.css
 }
 
 body {

--- a/scss/template/_core.scss
+++ b/scss/template/_core.scss
@@ -1,5 +1,5 @@
 html, body {
-	height: 100% !important; // user !important to override slidebars.min.css
+	height: 100% !important; // use !important to override slidebars.min.css
 }
 
 body {


### PR DESCRIPTION
`html, body { height: 100%; }` was overridden in `slidebars.min.css`,
so it was impossible to create content elements with 100% page height.

Changing that required to also change `antimatter.js` to bind the scroll
event to the `body` element instead of the document because Slidebars'
`x-overflow: hidden` (see http://stackoverflow.com/questions/17665080).