### PR TITLE
Limit display to visible posts

### DIFF
--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -1,6 +1,6 @@
 {% embed 'partials/base.html.twig' %}
 
-	{% set collection = page.collection() %}
+	{% set collection = page.collection().visible %}
 
 	{% block content %}
 		{% set blog_image = page.media.images|first.grayscale().contrast(20).brightness(-100).colorize(-35,81,122) %}


### PR DESCRIPTION
It seems that the current theme displays any post, not taking into account the visible value in the header. Adding an option to limit the collection to visible items, not sure if it is the best place to do that but it seems to fix the bug for blogs.