### PR TITLE
Custom Translatable Menu Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ menu:
         en: Source
         de: Quellcode
       url: https://github.com/getgrav/grav
-    - icon:
+    - text:
         en: Contact
         de: Kontakt
       url:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Antimatter is the default [Grav](http://getgrav.org) theme. Simple, fast and mod
 
 # Installation
 
-Installing the Antimatter theme can be done in one of two ways. Our GPM (Grav Package Manager) installation method enables you to quickly and easily install the theme with a simple terminal command, while the manual method enables you to do so via a zip file. 
+Installing the Antimatter theme can be done in one of two ways. Our GPM (Grav Package Manager) installation method enables you to quickly and easily install the theme with a simple terminal command, while the manual method enables you to do so via a zip file.
 
 The theme by itself is useful, but you may have an easier time getting up and running by installing a skeleton. The Antimatter theme can be found in both the [One-page](https://github.com/getgrav/grav-skeleton-onepage-site) and [Blog Site](https://github.com/getgrav/grav-skeleton-blog-site) which are self-contained repositories for a complete sites which include: sample content, configuration, theme, and plugins.
 
@@ -112,6 +112,24 @@ menu:
 ```
 
 The `url:` option is required, but you can provide **either** or **both** `text:` and/or `icon:`
+
+You can add multiple language support by adding a map with language prefixes (eg. `en`, `de`) to the menu items. You even can specify addresses based on the current language:
+
+```
+menu:
+    - text:
+        en: Source
+        de: Quellcode
+      url: https://github.com/getgrav/grav
+    - icon:
+        en: Contact
+        de: Kontakt
+      url:
+        en: /en/contact
+        de: /de/kontakt
+    - icon: twitter
+      url: http://twitter.com/getgrav
+```
 
 ### Blog Features
 

--- a/templates/partials/navigation.html.twig
+++ b/templates/partials/navigation.html.twig
@@ -15,6 +15,14 @@
     {% endfor %}
 {% endmacro %}
 
+{% macro getLanguageProperty(property, settings) %}
+    {% if property is iterable %}
+        {{ attribute(property, settings.getActive) is defined ? attribute(property, settings.getActive) : attribute(property, settings.default) }}
+    {% else %}
+        {{ property }}
+    {% endif %}
+{% endmacro %}
+
 <ul class="navigation">
     {% if theme_config.dropdown.enabled %}
         {{ _self.loop(pages) }}
@@ -31,9 +39,9 @@
     {% endif %}
     {% for mitem in site.menu %}
         <li>
-            <a href="{{ mitem.url[grav.language.getActive]|default(mitem.url) }}">
+            <a href="{{ _self.getLanguageProperty(mitem.url, grav.language) }}">
                 {% if mitem.icon %}<i class="fa fa-{{ mitem.icon }}"></i>{% endif %}
-                {{ mitem.text[grav.language.getActive]|default(mitem.text) }}
+                {{ _self.getLanguageProperty(mitem.text, grav.language) }}
             </a>
         </li>
     {% endfor %}

--- a/templates/partials/navigation.html.twig
+++ b/templates/partials/navigation.html.twig
@@ -31,9 +31,9 @@
     {% endif %}
     {% for mitem in site.menu %}
         <li>
-            <a href="{{ mitem.url }}">
+            <a href="{{ mitem.url[grav.language.getActive]|default(mitem.url) }}">
                 {% if mitem.icon %}<i class="fa fa-{{ mitem.icon }}"></i>{% endif %}
-                {{ mitem.text }}
+                {{ mitem.text[grav.language.getActive]|default(mitem.text) }}
             </a>
         </li>
     {% endfor %}


### PR DESCRIPTION
For a project I had to make the custom menu items translatable. With this adjustments, the custom title and link for a menu item is chosen in following order.

1. If the menuitem property (`text|url`) is not an array it has the default behaviour.
2. If it is an array, search for the value with the current language key.
3. If the current language does not exists, take the default language key.