### PR TITLE
Small change to translate Blog post date

### DIFF
--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -8,7 +8,7 @@
     <div class="list-blog-header">
         <span class="list-blog-date">
             <span>{{ page.date|date("d") }}</span>
-            <em>{{ page.date|date("M") }}</em>
+            <em>{{ 'MONTHS_OF_THE_YEAR'|ta(page.date|date('M Y')|date('n') -1) }} {{ month|date('Y') }}</em>
         </span>
         {% if page.header.link %}
             <h4>


### PR DESCRIPTION
I have changed line 11 to ensure that the date of each post will be translated automatically by using the 'Months of the year' which is present in the language.yaml (language folder).

Not sure if its the best or the 'right' way but it works for me.

Also I have added the year because over the course of a blog there will be different years for articles.