### PR TITLE
Basic microformats2 support

### DIFF
--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -18,7 +18,7 @@
 			{% endif %}
 
 		<div class="content-wrapper blog-content-list grid pure-g">
-			<div id="listing" class="block pure-u-2-3">
+			<div id="listing" class="block pure-u-2-3 h-feed">
 				{% for child in collection %}
 			        {% include 'partials/blog_item.html.twig' with {'blog':page, 'page':child, 'truncate':true} %}
 			    {% endfor %}

--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -6,7 +6,7 @@
 		{% endif %}
 		
 		<div class="blog-content-item grid pure-g-r">
-			<div id="item" class="block pure-u-2-3">
+			<div id="item" class="block pure-u-2-3 h-entry">
 			    {% include 'partials/blog_item.html.twig' with {'blog':page.parent, 'truncate':false} %}
 			</div>
 			<div id="sidebar" class="block size-1-3 pure-u-1-3">

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -1,4 +1,4 @@
-<div class="list-item">
+<div class="list-item h-entry">
 
     {% set header_image = page.header.header_image|defined(true) %}
     {% set header_image_width  = page.header.header_image_width|defined(900) %}
@@ -7,24 +7,26 @@
 
     <div class="list-blog-header">
         <span class="list-blog-date">
-            <span>{{ page.date|date("d") }}</span>
-            <em>{{ page.date|date("M") }}</em>
+            <time class="dt-published" datetime="{{ page.date }}">
+                <span>{{ page.date|date("d") }}</span>
+                <em>{{ page.date|date("M") }}</em>
+            </time>
         </span>
         {% if page.header.link %}
-            <h4>
+            <h4 class="p-name">
                 {% if page.header.continue_link is not sameas(false) %}
-                <a href="{{ page.url }}"><i class="fa fa-angle-double-right"></i></a>
+                <a href="{{ page.url }}"><i class="fa fa-angle-double-right u-url"></i></a>
                 {% endif %}
-                <a href="{{ page.header.link }}">{{ page.title }}</a>
+                <a href="{{ page.header.link }}" class="u-url">{{ page.title }}</a>
             </h4>
         {% else %}
-            <h4><a href="{{ page.url }}">{{ page.title }}</a></h4>
+            <h4 class="p-name"><a href="{{ page.url }}" class="u-url">{{ page.title }}</a></h4>
         {% endif %}
 
         {% if page.taxonomy.tag %}
         <span class="tags">
             {% for tag in page.taxonomy.tag %}
-            <a href="{{ blog.url|rtrim('/') }}/tag{{ config.system.param_sep }}{{ tag }}">{{ tag }}</a>
+            <a href="{{ blog.url|rtrim('/') }}/tag{{ config.system.param_sep }}{{ tag }}" class="p-category">{{ tag }}</a>
             {% endfor %}
         </span>
         {% endif %}
@@ -42,22 +44,32 @@
     <div class="list-blog-padding">
 
     {% if page.header.continue_link is sameas(false) %}
-        {{ page.content }}
+        <div class="e-content">        
+            {{ page.content }}
+        </div>
         {% if not truncate %}
         {% set show_prev_next = true %}
         {% endif %}
     {% elseif truncate and page.summary != page.content %}
-        {{ page.summary }}
-        <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
+        <div class="p-summary">
+            {{ page.summary }}
+            <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
+        </div>
     {% elseif truncate %}
-        {% if page.summary != page.content %}
-            {{ page.content|truncate(550) }}
-        {% else %}
-            {{ page.content }}
-        {% endif %}
-        <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
+        <div class="p-summary>
+            {% if page.summary != page.content %}
+                    {{ page.content|truncate(550) }}
+                </div>
+            {% else %}
+                    {{ page.content }}
+                
+            {% endif %}
+            <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
+        </div>
     {% else %}
-        {{ page.content }}
+        <div class="e-content">
+            {{ page.content }}
+        </div>
 
         {% if config.plugins.comments.enabled %}
             {% include 'partials/comments.html.twig' %}

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -7,7 +7,7 @@
 
     <div class="list-blog-header">
         <span class="list-blog-date">
-            <time class="dt-published" datetime="{{ page.date }}">
+            <time class="dt-published" datetime="{{ page.date|date("c") }}">
                 <span>{{ page.date|date("d") }}</span>
                 <em>{{ page.date|date("M") }}</em>
             </time>

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -51,12 +51,12 @@
         {% set show_prev_next = true %}
         {% endif %}
     {% elseif truncate and page.summary != page.content %}
-        <div class="p-summary">
+        <div class="p-summary e-content">
             {{ page.summary }}
             <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
         </div>
     {% elseif truncate %}
-        <div class="p-summary>
+        <div class="p-summary e-content">
             {% if page.summary != page.content %}
                     {{ page.content|truncate(550) }}
                 </div>


### PR DESCRIPTION
This pull-requests adds basic [microformats2](https://indieweb.org/microformats) markup to Antimatter's templates.

Each blog entry has the h-entry class and contains the following informations:
- dt-published with ISO8601 representation of the publication date
- p-name with the name of the entry
- e-content for the actual content (blog post)
- p-summary if the displayed content is only the summary
- p-category for tags

Still missing support for h-card in h-entries for authorship information (will add it in a next PR).