### PR TITLE
microformats2 markup + translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # v2.0.0-beta.2
+## 07/08/2016
+
+1. [](#new)
+    * Added translation string for feed description
+    * Added translation of months in the date of blog-items (thanks to @JohnMica) with a config option to enable/disable
+1. [](#improved)
+    * Changed h-feed properties (name and description set properly)
+
 ## 06/xx/2016
 
 1. [](#new)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ Antimatter supports the ability for a page to have a `link:` header option.  Thi
 link: http://getgrav.org/blog
 ```
 
+#### Multi-lingual dates for blog items
+
+Antimatter supports translations for dates.
+
+You can enable this in your `user/config/themes/antimatter.yaml` configuration file, or through the administration interface using the [admin](https://github.com/getgrav/grav-plugin-admin) plugin.
+
+```
+date:
+  translate: true
+```
+
 # Setup
 
 If you want to set Antimatter as the default theme, you can do so by following these steps:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Antimatter supports the ability for a page to have a `link:` header option.  Thi
 link: http://getgrav.org/blog
 ```
 
-#### Multi-lingual dates for blog items
+##### Multi-lingual dates for blog items
 
 Antimatter supports translations for dates.
 

--- a/antimatter.yaml
+++ b/antimatter.yaml
@@ -1,3 +1,5 @@
 enabled: true
 dropdown:
   enabled: false
+date:
+  translate: false

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -26,3 +26,13 @@ form:
           0: PLUGIN_ADMIN.DISABLED
         validate:
           type: bool
+    date.translate:
+        type: toggle
+        label: Translate dates
+        highlight: 1
+        default: 0
+        options:
+          1: PLUGIN_ADMIN.ENABLED
+          0: PLUGIN_ADMIN.DISABLED
+        validate:
+          type: bool

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,6 +1,8 @@
 en:
   TRANSLATION_TEST: Antimatter!
   BLOG:
+    FEED:
+      DESCRIPTION: %s's latest articles.
     ITEM:
       CONTINUE_READING: Continue reading...
       NEXT_POST: Next Post
@@ -82,6 +84,8 @@ es:
 fr:
   TRANSLATION_TEST: Antimatter !
   BLOG:
+    FEED:
+      DESCRIPTION: Les derniers articles de %s.
     ITEM:
       CONTINUE_READING: Continuer la lecture...
       NEXT_POST: Article suivant

--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -18,7 +18,7 @@
 			{% endif %}
 
 		<div class="content-wrapper blog-content-list grid pure-g">
-			<div id="listing" class="block pure-u-2-3">
+			<div id="listing" class="block pure-u-2-3 h-feed">
 				{% for child in collection %}
 			        {% include 'partials/blog_item.html.twig' with {'blog':page, 'page':child, 'truncate':true} %}
 			    {% endfor %}

--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -19,6 +19,10 @@
 
 		<div class="content-wrapper blog-content-list grid pure-g">
 			<div id="listing" class="block pure-u-2-3 h-feed">
+				<div style="display: none">
+			        <a href="{{ page.slug }}" class="p-name u-url">{% if header.title %}{{ header.title|e('html') }} | {% endif %}{{ site.title|e('html') }}</a>
+			        <p class="p-summary">{{ site.title|e('html')}}'s latest articles.</p>
+			    </div>
 				{% for child in collection %}
 			        {% include 'partials/blog_item.html.twig' with {'blog':page, 'page':child, 'truncate':true} %}
 			    {% endfor %}

--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -20,8 +20,8 @@
 		<div class="content-wrapper blog-content-list grid pure-g">
 			<div id="listing" class="block pure-u-2-3 h-feed">
 				<div style="display: none">
-			        <a href="{{ page.url(true) }}" class="p-name u-url">{{ page.title|e }}</a>
-			        <p class="p-summary">{{ "BLOG.FEED.DESCRIPTION"|t(site.title|e) }}</p>
+			        <a href="{{ page.url(true) }}" class="p-name u-url">{{ site.title ~ ' | ' ~ page.title }}</a>
+			        <p class="p-summary">{{ "BLOG.FEED.DESCRIPTION"|t(page.title|e) ~ ' @ ' ~ site.title }}</p>
 			    </div>
 				{% for child in collection %}
 			        {% include 'partials/blog_item.html.twig' with {'blog':page, 'page':child, 'truncate':true} %}

--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -20,8 +20,8 @@
 		<div class="content-wrapper blog-content-list grid pure-g">
 			<div id="listing" class="block pure-u-2-3 h-feed">
 				<div style="display: none">
-			        <a href="{{ page.slug }}" class="p-name u-url">{% if header.title %}{{ header.title|e('html') }} | {% endif %}{{ site.title|e('html') }}</a>
-			        <p class="p-summary">{{ site.title|e('html')}}'s latest articles.</p>
+			        <a href="{{ page.url(true) }}" class="p-name u-url">{{ page.title|e }}</a>
+			        <p class="p-summary">{{ "BLOG.FEED.DESCRIPTION"|t(site.title|e) }}</p>
 			    </div>
 				{% for child in collection %}
 			        {% include 'partials/blog_item.html.twig' with {'blog':page, 'page':child, 'truncate':true} %}

--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -6,7 +6,7 @@
 		{% endif %}
 		
 		<div class="blog-content-item grid pure-g-r">
-			<div id="item" class="block pure-u-2-3">
+			<div id="item" class="block pure-u-2-3 h-entry">
 			    {% include 'partials/blog_item.html.twig' with {'blog':page.parent, 'truncate':false} %}
 			</div>
 			<div id="sidebar" class="block size-1-3 pure-u-1-3">

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -9,7 +9,7 @@
         <span class="list-blog-date">
             <time class="dt-published" datetime="{{ page.date|date("c") }}">
                 <span>{{ page.date|date("d") }}</span>
-                <em>{{ page.date|date("M") }}</em>
+                <em>{{ 'MONTHS_OF_THE_YEAR'|ta(page.date|date('M Y')|date('n') -1) }} {{ month|date('Y') }}</em>
             </time>
         </span>
         {% if page.header.link %}

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -62,7 +62,6 @@
                 </div>
             {% else %}
                     {{ page.content }}
-                
             {% endif %}
             <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
         </div>

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -9,8 +9,12 @@
         <span class="list-blog-date">
             <time class="dt-published" datetime="{{ page.date|date("c") }}">
                 <span>{{ page.date|date("d") }}</span>
+                {% if theme_config.date.translate %}
                 <em>{{ 'MONTHS_OF_THE_YEAR'|ta(page.date|date('M Y')|date('n') -1) }} {{ month|date('Y') }}</em>
-            </time>
+                {% else %}
+                <em>{{ page.date|date("M") }}</em>
+                {% endif %}
+            </title>
         </span>
         {% if page.header.link %}
             <h4 class="p-name">

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -1,4 +1,4 @@
-<div class="list-item">
+<div class="list-item h-entry">
 
     {% set header_image = page.header.header_image|defined(true) %}
     {% set header_image_width  = page.header.header_image_width|defined(900) %}
@@ -7,24 +7,26 @@
 
     <div class="list-blog-header">
         <span class="list-blog-date">
-            <span>{{ page.date|date("d") }}</span>
-            <em>{{ page.date|date("M") }}</em>
+            <time class="dt-published" datetime="{{ page.date }}">
+                <span>{{ page.date|date("d") }}</span>
+                <em>{{ page.date|date("M") }}</em>
+            </time>
         </span>
         {% if page.header.link %}
-            <h4>
+            <h4 class="p-name">
                 {% if page.header.continue_link is not sameas(false) %}
-                <a href="{{ page.url }}"><i class="fa fa-angle-double-right"></i></a>
+                <a href="{{ page.url }}"><i class="fa fa-angle-double-right u-url"></i></a>
                 {% endif %}
-                <a href="{{ page.header.link }}">{{ page.title }}</a>
+                <a href="{{ page.header.link }}" class="u-url">{{ page.title }}</a>
             </h4>
         {% else %}
-            <h4><a href="{{ page.url }}">{{ page.title }}</a></h4>
+            <h4 class="p-name"><a href="{{ page.url }}" class="u-url">{{ page.title }}</a></h4>
         {% endif %}
 
         {% if page.taxonomy.tag %}
         <span class="tags">
             {% for tag in page.taxonomy.tag %}
-            <a href="{{ blog.url|rtrim('/') }}/tag{{ config.system.param_sep }}{{ tag }}">{{ tag }}</a>
+            <a href="{{ blog.url|rtrim('/') }}/tag{{ config.system.param_sep }}{{ tag }}" class="p-category">{{ tag }}</a>
             {% endfor %}
         </span>
         {% endif %}
@@ -42,22 +44,32 @@
     <div class="list-blog-padding">
 
     {% if page.header.continue_link is sameas(false) %}
-        {{ page.content }}
+        <div class="e-content">        
+            {{ page.content }}
+        </div>
         {% if not truncate %}
         {% set show_prev_next = true %}
         {% endif %}
     {% elseif truncate and page.summary != page.content %}
-        {{ page.summary }}
-        <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
+        <div class="p-summary">
+            {{ page.summary }}
+            <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
+        </div>
     {% elseif truncate %}
-        {% if page.summary != page.content %}
-            {{ page.content|truncate(550) }}
-        {% else %}
-            {{ page.content }}
-        {% endif %}
-        <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
+        <div class="p-summary>
+            {% if page.summary != page.content %}
+                    {{ page.content|truncate(550) }}
+                </div>
+            {% else %}
+                    {{ page.content }}
+                
+            {% endif %}
+            <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
+        </div>
     {% else %}
-        {{ page.content }}
+        <div class="e-content">
+            {{ page.content }}
+        </div>
 
         {% if config.plugins.comments.enabled %}
             {% include 'partials/comments.html.twig' %}

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -7,7 +7,7 @@
 
     <div class="list-blog-header">
         <span class="list-blog-date">
-            <time class="dt-published" datetime="{{ page.date }}">
+            <time class="dt-published" datetime="{{ page.date|date("c") }}">
                 <span>{{ page.date|date("d") }}</span>
                 <em>{{ page.date|date("M") }}</em>
             </time>

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -51,12 +51,12 @@
         {% set show_prev_next = true %}
         {% endif %}
     {% elseif truncate and page.summary != page.content %}
-        <div class="p-summary">
+        <div class="p-summary e-content">
             {{ page.summary }}
             <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
         </div>
     {% elseif truncate %}
-        <div class="p-summary>
+        <div class="p-summary e-content">
             {% if page.summary != page.content %}
                     {{ page.content|truncate(550) }}
                 </div>


### PR DESCRIPTION
- Added/fixed microformats2 feed (h-feed) properties.
- Feed description is provided by translation strings (English and French provided).
- Months of the year are now translated [thanks to @JohnMica](https://github.com/getgrav/grav-theme-antimatter/pull/55). An setting can enable or disable this feature (disabled by default for backwards-compatibility).