### PR TITLE
Added h-feed name and description

### DIFF
--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -19,6 +19,10 @@
 
 		<div class="content-wrapper blog-content-list grid pure-g">
 			<div id="listing" class="block pure-u-2-3 h-feed">
+				<div style="display: none">
+					<a href="{{ page.url }}" class="p-name u-url">{{ page.title }}</a>
+				<p class="p-summary">{{ header.feed.description }}</p>
+				</div>
 				{% for child in collection %}
 			        {% include 'partials/blog_item.html.twig' with {'blog':page, 'page':child, 'truncate':true} %}
 			    {% endfor %}


### PR DESCRIPTION
Just some more microformats2 for setting feed name and description.

Just like in feed plugin, name defaults to `page.title` and description to `head.feed.description` (here, defaults back to `page.title`if not set).