### PR TITLE
fix typo in Croatian translation

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -237,5 +237,6 @@ hr:
     SYNDICATE:
       HEADLINE: Kanali
   FORM_DATA:
-    SUMMARY: "Ovo je sažetakj onog što ste nam napisali:"
+    SUMMARY: "Ovo je sažetak onog što ste nam napisali:"
   ERROR: Greška
+  


### PR DESCRIPTION
Fixed typo in Croatian translation.

Sincerely,
Gour