### PR TITLE
Remove font import

### DIFF
--- a/css-compiled/template.css
+++ b/css-compiled/template.css
@@ -1,4 +1,3 @@
-@import url(//fonts.googleapis.com/css?family=Montserrat:400|Raleway:300,400,600|Inconsolata);
 #header #logo h3, #header #navbar .panel-activation, #footer p {
   position: relative;
   top: 50%;

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -16,6 +16,7 @@
         {% do assets.addCss('theme://css-compiled/template.css', 101) %}
         {% do assets.addCss('theme://css/custom.css', 100) %}
         {% do assets.addCss('theme://css/font-awesome.min.css', 100) %}
+        {% do assets.addCss('//fonts.googleapis.com/css?family=Montserrat:400|Raleway:300,400,600|Inconsolata') %}
         {% do assets.addCss('theme://css/slidebars.min.css') %}
 
         {% if browser.getBrowser == 'msie' and browser.getVersion == 10 %}


### PR DESCRIPTION
This PR removes a font import from a template css file. The font is added via the asset manager in base.html.twig, so it can benefit from optimizations of the css pipeline.
