### PR TITLE
Removed unreachable condition

### DIFF
--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -57,13 +57,7 @@
         </div>
     {% elseif truncate %}
         <div class="p-summary e-content">
-            {% if page.summary != page.content %}
-                    {{ page.content|truncate(550) }}
-                </div>
-            {% else %}
-                    {{ page.content }}
-                
-            {% endif %}
+            {{ page.content }}
             <p><a href="{{ page.url }}">{{ 'BLOG.ITEM.CONTINUE_READING'|t }}</a></p>
         </div>
     {% else %}


### PR DESCRIPTION
See issue #83. The 2nd condition `{% if page.summary != page.content %}` was redundant.