### PR TITLE
Move slidebar into block

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -75,12 +75,12 @@
         </footer>
         {% endblock %}
     </div>
-    <div class="sb-slidebar sb-left sb-width-thin">
-        <div id="panel">
-        {% include 'partials/navigation.html.twig' %}
-        </div>
-    </div>
     {% block bottom %}
+        <div class="sb-slidebar sb-left sb-width-thin">
+            <div id="panel">
+            {% include 'partials/navigation.html.twig' %}
+            </div>
+        </div>
         {{ assets.js('bottom') }}
         <script>
         $(function () {

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -75,7 +75,7 @@
         </footer>
         {% endblock %}
     </div>
-    {% block footer_navigation %}
+    {% block sidebar_navigation %}
         <div class="sb-slidebar sb-left sb-width-thin">
             <div id="panel">
             {% include 'partials/navigation.html.twig' %}

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -75,12 +75,14 @@
         </footer>
         {% endblock %}
     </div>
-    {% block bottom %}
+    {% block footer_navigation %}
         <div class="sb-slidebar sb-left sb-width-thin">
             <div id="panel">
             {% include 'partials/navigation.html.twig' %}
             </div>
         </div>
+    {% endblock %}
+    {% block bottom %}
         {{ assets.js('bottom') }}
         <script>
         $(function () {


### PR DESCRIPTION
Slidebar is currently not defined within a block, and thus by default renders in child-themes. Moving it into the bottom-block allows overriding the block without touching base.html.twig entirely, and does not change the HTML-structure.