### PR TITLE
Added .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+css-compiled/*	-diff


### PR DESCRIPTION
IMHO it's not quite useful to include files from the `css-compiled` directory in a `git diff`, so this option prevents this.